### PR TITLE
feat: Add Geek Uninstaller functionality

### DIFF
--- a/src/main/geekUninstaller.js
+++ b/src/main/geekUninstaller.js
@@ -1,0 +1,19 @@
+const { exec } = require('child_process');
+
+const geekUninstallerPath = ('./geek.exe');
+
+const launchGeekUninstaller = () => {
+  exec(geekUninstallerPath, (err, stdout, stderr) => {
+    if (err) {
+      console.error('Error launching Geek Uninstaller:', err);
+      return;
+    }
+    if (stderr) {
+      console.error(`stderr: ${stderr}`);
+      return;
+    }
+    console.log(`stdout: ${stdout}`);
+  })
+}
+
+module.exports = launchGeekUninstaller;

--- a/src/main/removeApp.js
+++ b/src/main/removeApp.js
@@ -1,0 +1,75 @@
+const axios = require('axios');
+const config = require('../../config');
+const fs = require('fs');
+const os = require('os');
+const getUserData = require('./getUserData');
+
+
+// Define paths to software executables
+const getSoftwarePaths = () => {
+  const platform = os.platform();
+  if (platform === 'win32') {
+    return {
+      'Bitwarden': [
+        'C:\\Program Files\\Bitwarden',
+        'C:\\Program Files (x86)\\Bitwarden'
+      ],
+      'Privazer': [
+        'C:\\Program Files\\PrivaZer',
+        'C:\\Program Files (x86)\\PrivaZer'
+      ],
+    };
+  } else if (platform === 'darwin') {
+    return {
+      'Bitwarden': '/Applications/Bitwarden',
+      'Privazer': '/Applications/PrivaZer',
+    };
+  } else if (platform === 'linux') {
+    return {
+      'Bitwarden': '/usr/bin/bitwarden',
+      'Privazer': '/usr/bin/privaZer',
+    };
+  }
+};
+
+const softwarePaths = getSoftwarePaths();
+
+// Function to check if software is installed
+const isSoftwareInstalled = (software) => {
+  const softwarePath = softwarePaths[software];
+  // Vérification si les chemins récupérés sont un tableau:
+  if (Array.isArray(softwarePath)) {
+    return softwarePath.some(paths => fs.existsSync(paths));
+  }
+  return fs.existsSync(softwarePath);
+}
+
+// Function to delete software from download history if not installed
+const deleteSoftware = async (mainWindow) => {
+  try {
+    const userData = await getUserData();
+    const downloadHistory = userData.downloadHistory;
+
+    console.log('Starting software check');
+
+    for (const download of downloadHistory) {
+      const softwareName = download.security_tool_id.name;
+      console.log('checking for software:', softwareName);
+      if (!isSoftwareInstalled(softwareName)) {
+        await axios.delete(`${config.api.url}/downloadHistory/${download._id}`);
+        console.log('Software deleted from download history:', softwareName);
+
+        // Send an IPC message to the renderer process
+        mainWindow.webContents.send('software-status-updated', {
+          softwareName: softwareName,
+          status: 'uninstalled'
+        });
+      }
+    }
+    console.log('Software check completed');
+  } catch (error) {
+    console.error('Error deleting software', error);
+  }
+};
+
+module.exports = deleteSoftware;

--- a/src/renderer/scripts/uninstallerPage.js
+++ b/src/renderer/scripts/uninstallerPage.js
@@ -1,0 +1,9 @@
+document.getElementById('launch-geek-uninstaller').addEventListener('click', () => {
+  ipcRenderer.invoke('launch-geek-uninstaller')
+    .then(() => {
+      console.log('Geek Uninstaller launched successfully');
+    })
+    .catch((error) => {
+      console.error('Error launching Geek Uninstaller:', error);
+    });
+});


### PR DESCRIPTION
This commit adds the necessary code to launch Geek Uninstaller from the application. The `geekUninstaller.js` file is created to handle the execution of the `geek.exe` file. When the `launch-geek-uninstaller` button is clicked on the uninstaller page, the `ipcRenderer` is used to invoke the `launch-geek-uninstaller` event, which triggers the execution of Geek Uninstaller. Any errors encountered during the execution are logged to the console.